### PR TITLE
Feat: ManyToOne 관계 고려하여 order, product Entity의 테이블 생성

### DIFF
--- a/api/src/main/java/com/von/api/account/Account.java
+++ b/api/src/main/java/com/von/api/account/Account.java
@@ -1,33 +1,33 @@
-package com.von.api.account;
-
-import lombok.*;
-
-import java.time.LocalDate;
-import jakarta.persistence.*;
-
-
-@Entity(name = "account")
-@NoArgsConstructor (access = AccessLevel.PROTECTED)
-@Getter
-@ToString (exclude = {"id"})
-
-public class Account {
-
-    @Id
-    @Column(name = "id", nullable = false)
-    @GeneratedValue(strategy = GenerationType.AUTO)
-    private Long id;
-    private String accountNumber;
-    private String accountHolder;
-    private Double balance;
-    private LocalDate transactionDate;
-
-@Builder(builderMethodName = "builder")
-    public Account(Long id, String accountNumber, String accountHolder, Double balance, LocalDate transactionDate) {
-        this.id = id;
-        this.accountNumber = accountNumber;
-        this.accountHolder = accountHolder;
-        this.balance = balance;
-        this.transactionDate = transactionDate;
-    }
-}
+//package com.von.api.account;
+//
+//import lombok.*;
+//
+//import java.time.LocalDate;
+//import jakarta.persistence.*;
+//
+//
+//@Entity(name = "account")
+//@NoArgsConstructor (access = AccessLevel.PROTECTED)
+//@Getter
+//@ToString (exclude = {"id"})
+//
+//public class Account {
+//
+//    @Id
+//    @Column(name = "id", nullable = false)
+//    @GeneratedValue(strategy = GenerationType.AUTO)
+//    private Long id;
+//    private String accountNumber;
+//    private String accountHolder;
+//    private Double balance;
+//    private LocalDate transactionDate;
+//
+//@Builder(builderMethodName = "builder")
+//    public Account(Long id, String accountNumber, String accountHolder, Double balance, LocalDate transactionDate) {
+//        this.id = id;
+//        this.accountNumber = accountNumber;
+//        this.accountHolder = accountHolder;
+//        this.balance = balance;
+//        this.transactionDate = transactionDate;
+//    }
+//}

--- a/api/src/main/java/com/von/api/account/AccountController.java
+++ b/api/src/main/java/com/von/api/account/AccountController.java
@@ -1,60 +1,60 @@
-package com.von.api.account;
-
-
-import com.von.api.enums.Messenger;
-import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RestController;
-
-import java.time.LocalDate;
-import java.util.List;
-import java.util.Scanner;
-
-@RestController
-@RequiredArgsConstructor
-public class AccountController {
-    private final AccountServiceImpl acServ;
-
-    public Messenger createAccount(Scanner scan) {
-        System.out.println("id, acNum, acH, bal");
-        return acServ.save(Account.builder()
-                .id(scan.nextLong())
-                .accountNumber(scan.next())
-                .accountHolder(scan.next())
-                .balance(scan.nextDouble())
-                .transactionDate(LocalDate.now())
-                .build());
-    }
-
-    public String deposit(Scanner scan) {
-        return acServ.deposit(Account.builder()
-                .id(scan.nextLong())
-                .accountNumber(scan.next())
-                .accountHolder(scan.next())
-                .balance(scan.nextDouble())
-                .transactionDate(null)
-                .build());
-    }
-
-    public String withdraw(Scanner scan) {
-        return acServ.withdraw(Account.builder()
-                .id(scan.nextLong())
-                .accountNumber(scan.next())
-                .accountHolder(scan.next())
-                .balance(scan.nextDouble())
-                .transactionDate(null)
-                .build());
-    }
-
-    public String getBalance(Scanner scan) {
-        return acServ.getBalance(scan.next());
-    }
-
-    public String cancelAccount(Scanner scan) {
-        System.out.println("Insert accountNumber to remove");
-        return acServ.delete(Account.builder().accountNumber(scan.next()).build());
-    }
-
-    public List<?> getAccounts() {
-        return acServ.findAll();
-    }
-}
+//package com.von.api.account;
+//
+//
+//import com.von.api.enums.Messenger;
+//import lombok.RequiredArgsConstructor;
+//import org.springframework.web.bind.annotation.RestController;
+//
+//import java.time.LocalDate;
+//import java.util.List;
+//import java.util.Scanner;
+//
+//@RestController
+//@RequiredArgsConstructor
+//public class AccountController {
+//    private final AccountServiceImpl acServ;
+//
+//    public Messenger createAccount(Scanner scan) {
+//        System.out.println("id, acNum, acH, bal");
+//        return acServ.save(Account.builder()
+//                .id(scan.nextLong())
+//                .accountNumber(scan.next())
+//                .accountHolder(scan.next())
+//                .balance(scan.nextDouble())
+//                .transactionDate(LocalDate.now())
+//                .build());
+//    }
+//
+//    public String deposit(Scanner scan) {
+//        return acServ.deposit(Account.builder()
+//                .id(scan.nextLong())
+//                .accountNumber(scan.next())
+//                .accountHolder(scan.next())
+//                .balance(scan.nextDouble())
+//                .transactionDate(null)
+//                .build());
+//    }
+//
+//    public String withdraw(Scanner scan) {
+//        return acServ.withdraw(Account.builder()
+//                .id(scan.nextLong())
+//                .accountNumber(scan.next())
+//                .accountHolder(scan.next())
+//                .balance(scan.nextDouble())
+//                .transactionDate(null)
+//                .build());
+//    }
+//
+//    public String getBalance(Scanner scan) {
+//        return acServ.getBalance(scan.next());
+//    }
+//
+//    public String cancelAccount(Scanner scan) {
+//        System.out.println("Insert accountNumber to remove");
+//        return acServ.delete(Account.builder().accountNumber(scan.next()).build());
+//    }
+//
+//    public List<?> getAccounts() {
+//        return acServ.findAll();
+//    }
+//}

--- a/api/src/main/java/com/von/api/account/AccountService.java
+++ b/api/src/main/java/com/von/api/account/AccountService.java
@@ -1,8 +1,8 @@
-package com.von.api.account;
-
-
-public interface AccountService {
-    String deposit(Account dto);
-    String withdraw(Account dto);
-    String getBalance(String accountNumber);
-}
+//package com.von.api.account;
+//
+//
+//public interface AccountService {
+//    String deposit(Account dto);
+//    String withdraw(Account dto);
+//    String getBalance(String accountNumber);
+//}

--- a/api/src/main/java/com/von/api/account/AccountServiceImpl.java
+++ b/api/src/main/java/com/von/api/account/AccountServiceImpl.java
@@ -1,70 +1,70 @@
-package com.von.api.account;
-
-
-import com.von.api.common.AbstractService;
-import com.von.api.enums.Messenger;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-
-@Service
-@RequiredArgsConstructor
-public class AccountServiceImpl extends AbstractService<Account> implements AccountService {
-
-    @Override
-    public String deposit(Account dto) {
-        return null;
-    }
-    @Override
-    public String withdraw(Account dto) {
-        return null;
-    }
-
-    @Override
-    public String getBalance(String accountNumber) {
-        return null;
-    }
-
-    @Override
-    public Messenger save(Account account) {
-        return null;
-    }
-
-    @Override
-    public List<Account> findAll() {
-        return null;
-    }
-
-    @Override
-    public Optional<Account> findById(Long id) {
-        return Optional.empty();
-    }
-
-    @Override
-    public String count() {
-        return null;
-    }
-
-    @Override
-    public Optional<Account> getOne(String id) {
-        return Optional.empty();
-    }
-
-    @Override
-    public String delete(Account account) {
-        return null;
-    }
-
-    @Override
-    public String deleteAll() {
-        return null;
-    }
-
-    @Override
-    public Boolean existById(Long id) {
-        return null;
-    }
-}
+//package com.von.api.account;
+//
+//
+//import com.von.api.common.AbstractService;
+//import com.von.api.enums.Messenger;
+//import lombok.RequiredArgsConstructor;
+//import org.springframework.stereotype.Service;
+//
+//import java.util.ArrayList;
+//import java.util.List;
+//import java.util.Optional;
+//
+//@Service
+//@RequiredArgsConstructor
+//public class AccountServiceImpl extends AbstractService<Account> implements AccountService {
+//
+//    @Override
+//    public String deposit(Account dto) {
+//        return null;
+//    }
+//    @Override
+//    public String withdraw(Account dto) {
+//        return null;
+//    }
+//
+//    @Override
+//    public String getBalance(String accountNumber) {
+//        return null;
+//    }
+//
+//    @Override
+//    public Messenger save(Account account) {
+//        return null;
+//    }
+//
+//    @Override
+//    public List<Account> findAll() {
+//        return null;
+//    }
+//
+//    @Override
+//    public Optional<Account> findById(Long id) {
+//        return Optional.empty();
+//    }
+//
+//    @Override
+//    public String count() {
+//        return null;
+//    }
+//
+//    @Override
+//    public Optional<Account> getOne(String id) {
+//        return Optional.empty();
+//    }
+//
+//    @Override
+//    public String delete(Account account) {
+//        return null;
+//    }
+//
+//    @Override
+//    public String deleteAll() {
+//        return null;
+//    }
+//
+//    @Override
+//    public Boolean existById(Long id) {
+//        return null;
+//    }
+//}

--- a/api/src/main/java/com/von/api/article/ArticleController.java
+++ b/api/src/main/java/com/von/api/article/ArticleController.java
@@ -1,6 +1,5 @@
 package com.von.api.article;
 
-import com.von.api.account.AccountServiceImpl;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -10,7 +9,7 @@ import java.util.List;
 @RestController
 @RequiredArgsConstructor
 public class ArticleController {
-    private final AccountServiceImpl service;
+    private final ArticleService service;
 
     public List<Article> findAll() throws SQLException {
         return null;

--- a/api/src/main/java/com/von/api/order/Order.java
+++ b/api/src/main/java/com/von/api/order/Order.java
@@ -1,0 +1,44 @@
+package com.von.api.order;
+
+import com.von.api.product.Product;
+import com.von.api.user.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDate;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@ToString(exclude = {"id"})
+
+@Entity(name = "orders")
+public class Order {
+
+    @Id
+    @Column(name = "orderId", nullable = false)
+    @GeneratedValue(strategy = GenerationType.AUTO)
+
+    private Long id;
+
+    private LocalDate orderDate;
+
+    private Integer orderAmount;
+
+    @ManyToOne
+    @JoinColumn(name = "product_id")
+    private Product product;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Builder(builderMethodName = "builder")
+
+    public Order(Long id, LocalDate orderDate, Integer orderAmount, Product product, User user) {
+        this.id = id;
+        this.orderDate = orderDate;
+        this.orderAmount = orderAmount;
+        this.product = product;
+        this.user = user;
+    }
+}

--- a/api/src/main/java/com/von/api/order/OrderController.java
+++ b/api/src/main/java/com/von/api/order/OrderController.java
@@ -1,0 +1,4 @@
+package com.von.api.order;
+
+public class OrderController {
+}

--- a/api/src/main/java/com/von/api/order/OrderRepository.java
+++ b/api/src/main/java/com/von/api/order/OrderRepository.java
@@ -1,0 +1,4 @@
+package com.von.api.order;
+
+public class OrderRepository {
+}

--- a/api/src/main/java/com/von/api/order/OrderService.java
+++ b/api/src/main/java/com/von/api/order/OrderService.java
@@ -1,0 +1,4 @@
+package com.von.api.order;
+
+public class OrderService {
+}

--- a/api/src/main/java/com/von/api/order/OrderServiceImpl.java
+++ b/api/src/main/java/com/von/api/order/OrderServiceImpl.java
@@ -1,0 +1,4 @@
+package com.von.api.order;
+
+public class OrderServiceImpl {
+}

--- a/api/src/main/java/com/von/api/product/Product.java
+++ b/api/src/main/java/com/von/api/product/Product.java
@@ -1,5 +1,31 @@
 package com.von.api.product;
 
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@ToString(exclude = {"id"})
+
+@Entity(name = "products")
 public class Product {
-    
+
+    @Id
+    @Column(name = "id",nullable = false)
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private Long id;
+
+
+    private String prodName;
+    private String prodPrice;
+    private String company;
+
+    @Builder(builderMethodName = "builder")
+    public Product(Long id, String prodName, String prodPrice, String company) {
+        this.id = id;
+        this.prodName = prodName;
+        this.prodPrice = prodPrice;
+        this.company = company;
+    }
 }

--- a/api/src/main/java/com/von/api/user/User.java
+++ b/api/src/main/java/com/von/api/user/User.java
@@ -1,11 +1,19 @@
 package com.von.api.user;
 
+import jakarta.persistence.*;
 import lombok.*;
+
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @ToString
+
+@Entity(name = "users")
 public class User {
+
+    @Id
+    @Column(name = "userId",nullable = false)
+    @GeneratedValue(strategy = GenerationType.AUTO)
     private Long id;
     private String userName;
     private String password;


### PR DESCRIPTION
양방향 관계를 권장하고 있지 않아(mappedBy 미사용 이유), 
product와 order, user와 order 2개의 단방향 관계로 고려하여 작성함.
user Entity는 담당이 아니기에 JPA 기능 외, 기존 코드에서 변경하지 않았음.